### PR TITLE
Add customCSS feature

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -8,6 +8,8 @@ disqusShortname = "hugo-massively"
 # [params]
   # set below parameter to define a favicon
   # favicon = "favicon.ico"
+  # define custom CSS paths here
+  # customCSS = [""]
 
 # Below parameters can be set to override default post settings
 # [params.posts]

--- a/layouts/partials/htmlhead.html
+++ b/layouts/partials/htmlhead.html
@@ -10,6 +10,11 @@
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 		<link rel="stylesheet" href='{{ "assets/css/main.css" | relURL }}' />
+		{{ range $val := $.Site.Params.customCSS }}
+			{{ if gt (len $val) 0 }}
+			<link rel="stylesheet" type="text/css" href="{{ $val }}">
+			{{ end }}
+		{{ end }}
 		{{ with .Site.Params.favicon }}
 		<link rel="shortcut icon" href="{{ . }}">
 		{{ end }}


### PR DESCRIPTION
This PR adds custom CSS feature to this theme. The usage is simple, define `customCSS` list under `params` in config file as follows:
```toml
[params]
customCSS = ["<absolute path to CSS>", "/static/test.css", "<or simply some link off the internet>"]
```
Multiple CSS loading is supported. I hope this solves #19 .